### PR TITLE
Add LIGHTS_MODE_DEFAULT_AND_BRAKE_LIGHT mode

### DIFF
--- a/src/firmware/app.c
+++ b/src/firmware/app.c
@@ -251,7 +251,8 @@ void app_set_lights(bool on)
 	}
 	else
 	{
-		if (LIGHTS_MODE == LIGHTS_MODE_DEFAULT && lights_state != on)
+		if (LIGHTS_MODE == LIGHTS_MODE_DEFAULT && lights_state != on ||
+			LIGHTS_MODE == LIGHTS_MODE_DEFAULT_AND_BRAKE_LIGHT && lights_state != on)
 		{
 			lights_state = on;
 			eventlog_write_data(EVT_DATA_LIGHTS, on);
@@ -752,6 +753,11 @@ bool apply_brake(uint8_t* target_current)
 
 	#if LIGHTS_MODE == LIGHTS_MODE_BRAKE_LIGHT
 		lights_set(is_braking);
+	#endif
+
+	#if LIGHTS_MODE == LIGHTS_MODE_DEFAULT_AND_BRAKE_LIGHT
+		if (!app_get_lights()) // If lights are on, don't use brake light
+			lights_set(is_braking);
 	#endif
 
 	if (is_braking)

--- a/src/firmware/constants.h
+++ b/src/firmware/constants.h
@@ -38,10 +38,11 @@
 #define THROTTLE_GLOBAL_SPEED_LIMIT_ENABLED		1
 #define THROTTLE_GLOBAL_SPEED_LIMIT_STD_LVLS	2
 
-#define LIGHTS_MODE_DEFAULT				0
-#define LIGHTS_MODE_DISABLED			1
-#define LIGHTS_MODE_ALWAYS_ON			2
-#define LIGHTS_MODE_BRAKE_LIGHT			3
+#define LIGHTS_MODE_DEFAULT						0
+#define LIGHTS_MODE_DISABLED					1
+#define LIGHTS_MODE_ALWAYS_ON					2
+#define LIGHTS_MODE_BRAKE_LIGHT					3
+#define LIGHTS_MODE_DEFAULT_AND_BRAKE_LIGHT		4 //When light is off, the light will be used as brake light, When its turned on it stays on
 
 #define CONFIG_VERSION					5
 #define PSTATE_VERSION					1


### PR DESCRIPTION
Add LIGHTS_MODE_DEFAULT_AND_BRAKE_LIGHT mode

Introduces a new lights mode to allow the light to function as a brake light when its off but keep its default behavior when its turned on. Useful when using the light output for a simple rear light.