### PR TITLE
Add option for pretension only in Sport mode

### DIFF
--- a/src/firmware/app.c
+++ b/src/firmware/app.c
@@ -360,12 +360,17 @@ uint8_t app_get_temperature()
 
 void apply_pretension(uint8_t* target_current)
 {
-	#if USE_SPEED_SENSOR && USE_PRETENSION
-		uint16_t current_speed_rpm_x10 = speed_sensor_get_rpm_x10();
+	#if USE_SPEED_SENSOR && (USE_PRETENSION || USE_PRETENSION_ONLY_IN_SPORT_MODE)
 
-		if (current_speed_rpm_x10 > pretension_cutoff_speed_rpm_x10)
+		//Check if we are in Sport mode or if pretensioning is also allowed in normal modes
+		if (!USE_PRETENSION_ONLY_IN_SPORT_MODE || operation_mode == OPERATION_MODE_SPORT)
 		{
-			*target_current = 1;
+			uint16_t current_speed_rpm_x10 = speed_sensor_get_rpm_x10();
+
+			if (current_speed_rpm_x10 > pretension_cutoff_speed_rpm_x10)
+			{
+				*target_current = 1;
+			}
 		}
 	#endif
 	return;

--- a/src/firmware/fwconfig.h
+++ b/src/firmware/fwconfig.h
@@ -30,6 +30,10 @@
 #define USE_SHIFT_SENSOR	HAS_SHIFT_SENSOR_SUPPORT
 #define USE_PUSH_WALK		1
 #define USE_PRETENSION		0
+// Use pretension only if we are currently in Sport Mode.
+//When this is enabled, "USE_PRETENSION" is beeing ignored.
+//Usefull for EU riding when the bike gets checked without load (wheel in the air). When Pretensioning is enabled it might turn your wheel indefinitely and you might get asked some annoying questions
+#define USE_PRETENSION_ONLY_IN_SPORT_MODE 1 
 #define PRETENSION_SPEED_CUTOFF_KPH 16
 #define USE_TEMPERATURE_SENSOR	TEMPERATURE_SENSOR_CONTR
 #define LIGHTS_MODE	LIGHTS_MODE_DEFAULT


### PR DESCRIPTION
Introduces USE_PRETENSION_ONLY_IN_SPORT_MODE to restrict pretensioning to Sport mode. Updates logic in apply_pretension to check operation mode, improving compliance for EU riding scenarios.